### PR TITLE
physical_spec: Use internal anycast addresses for rDNS

### DIFF
--- a/nixops_hetznercloud/backends/hetznercloud.py
+++ b/nixops_hetznercloud/backends/hetznercloud.py
@@ -221,9 +221,8 @@ class HetznerCloudState(MachineState[HetznerCloudDefinition]):
             # Hetzner Cloud networking defaults
             ("networking", "defaultGateway"): "172.31.1.1",
             ("networking", "nameservers"): [
-                "213.133.98.98",
-                "213.133.99.99",
-                "213.133.100.100",
+                "185.12.64.1",
+                "185.12.64.2",
             ],
             (
                 "networking",


### PR DESCRIPTION
In order to serve rDNS across multiple regions with different autonomous system numbers, Hetzner uses a non-announced IP space which is only reachable within the Hetzner network itself. This change is also required to use the correct rDNS servers in Ashburn.

Signed-off-by: Tom Siewert <tom@siewert.io>